### PR TITLE
chore: add top-level Package.swift to help VS Code/SourceKit indexing

### DIFF
--- a/Indexer/Sources/Indexer/main.swift
+++ b/Indexer/Sources/Indexer/main.swift
@@ -1,0 +1,5 @@
+import Foundation
+import TiercadeCore
+
+// Minimal entry that touches TiercadeCore to ensure SPM builds it for indexing
+print("Indexer running. Item types available: \(Item.self)")

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "TiercadeWorkspace",
+    platforms: [
+        .macOS(.v14),
+        .iOS(.v17),
+        .tvOS(.v17)
+    ],
+    dependencies: [
+        .package(path: "./TiercadeCore"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "Indexer",
+            dependencies: ["TiercadeCore"],
+            path: "Indexer/Sources/Indexer"
+        )
+    ]
+)

--- a/tmp/diag_test.swift
+++ b/tmp/diag_test.swift
@@ -1,0 +1,1 @@
+// removed


### PR DESCRIPTION
Add top-level Package.swift and Indexer target to enable VS Code SourceKit-LSP indexing. Temporary change to improve editor experience.