### PR TITLE
Restore SwiftData themes and toolbar polish

### DIFF
--- a/Tiercade/Design/TierThemeSchema.swift
+++ b/Tiercade/Design/TierThemeSchema.swift
@@ -1,0 +1,416 @@
+import Foundation
+import SwiftData
+
+@Model
+final class TierColorEntity {
+    @Attribute(.unique) var tierID: UUID
+    var index: Int
+    var name: String
+    var colorHex: String
+    var isUnranked: Bool
+
+    init(
+        tierID: UUID = UUID(),
+        index: Int,
+        name: String,
+        colorHex: String,
+        isUnranked: Bool = false
+    ) {
+        self.tierID = tierID
+        self.index = index
+        self.name = name
+        self.colorHex = colorHex
+        self.isUnranked = isUnranked
+    }
+}
+
+@Model
+final class TierThemeEntity {
+    @Attribute(.unique) var themeID: UUID
+    var slug: String
+    var displayName: String
+    var shortDescription: String
+    @Relationship(deleteRule: .cascade) var tiers: [TierColorEntity]
+
+    init(
+        themeID: UUID = UUID(),
+        slug: String,
+        displayName: String,
+        shortDescription: String,
+        tiers: [TierColorEntity]
+    ) {
+        self.themeID = themeID
+        self.slug = slug
+        self.displayName = displayName
+        self.shortDescription = shortDescription
+        self.tiers = tiers.sorted { left, right in
+            if left.isUnranked != right.isUnranked {
+                return !left.isUnranked
+            }
+            return left.index < right.index
+        }
+    }
+}
+
+@MainActor
+enum TierThemeSeeds {
+    static let defaults: [TierThemeEntity] = [
+        TierThemeEntity(
+            themeID: UUID(uuidString: "E96B8A5D-7E1F-4B6C-9D4A-8BC3F46F2E9C")!,
+            slug: "smashClassic",
+            displayName: "Smash Classic",
+            shortDescription: "Classic tier list colors",
+            tiers: [
+                TierColorEntity(
+                    tierID: UUID(uuidString: "6E5CE5A0-3D46-49F7-8A6C-1245C4B32EC6")!,
+                    index: 0,
+                    name: "S",
+                    colorHex: "#FF0000"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "3252B9B6-8B2B-4F4B-A7A6-38B12D7CE328")!,
+                    index: 1,
+                    name: "A",
+                    colorHex: "#FF8000"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "01F35ECA-6B60-4605-9E6C-2705D77EDB9A")!,
+                    index: 2,
+                    name: "B",
+                    colorHex: "#FFFF00"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "425D0B6F-4851-4E5C-A698-7A1F174F6E6B")!,
+                    index: 3,
+                    name: "C",
+                    colorHex: "#00FF00"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "2FD9249C-62E7-4D53-BF23-D51F4ACBB451")!,
+                    index: 4,
+                    name: "D",
+                    colorHex: "#0000FF"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "9F9D6E8D-5B94-4F9A-9122-BD8D4DF0ED6D")!,
+                    index: 5,
+                    name: "F",
+                    colorHex: "#808080"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "35DF7601-D8E3-46CA-84BA-3E58F66B8D91")!,
+                    index: 6,
+                    name: "Unranked",
+                    colorHex: "#6B7280",
+                    isUnranked: true
+                )
+            ]
+        ),
+        TierThemeEntity(
+            themeID: UUID(uuidString: "9CE1CE02-95A7-4AA2-86EC-7E9459B5A168")!,
+            slug: "heatmapGradient",
+            displayName: "Heatmap Gradient",
+            shortDescription: "Heat intensity gradient",
+            tiers: [
+                TierColorEntity(
+                    tierID: UUID(uuidString: "EB4B8FD0-4CC4-47BB-8C2A-DED5D9A1C112")!,
+                    index: 0,
+                    name: "S",
+                    colorHex: "#FF0000"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "FCF80DAA-A347-4A9E-86DC-2DB640FF2666")!,
+                    index: 1,
+                    name: "A",
+                    colorHex: "#FF8000"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "73EA00BF-4901-4A7E-A034-5735299D8E68")!,
+                    index: 2,
+                    name: "B",
+                    colorHex: "#FFFF00"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "CBB0E6BB-A406-48A8-A8F1-4606F9E4B61E")!,
+                    index: 3,
+                    name: "C",
+                    colorHex: "#00FF00"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "5511E48D-0B29-4330-B434-C65E9AE312CE")!,
+                    index: 4,
+                    name: "D",
+                    colorHex: "#0080FF"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "FF96413D-1A74-43B5-A6C7-38B7A0460C51")!,
+                    index: 5,
+                    name: "F",
+                    colorHex: "#8000FF"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "EBA2420E-DB3E-4C03-932C-0B0C5F6E4575")!,
+                    index: 6,
+                    name: "Unranked",
+                    colorHex: "#808080",
+                    isUnranked: true
+                )
+            ]
+        ),
+        TierThemeEntity(
+            themeID: UUID(uuidString: "E17A24C3-EBB1-4017-A16C-8556F1DA7D92")!,
+            slug: "pastel",
+            displayName: "Pastel",
+            shortDescription: "Soft, muted tones",
+            tiers: [
+                TierColorEntity(
+                    tierID: UUID(uuidString: "4D109675-8B18-4A43-909B-616C1D527C45")!,
+                    index: 0,
+                    name: "S",
+                    colorHex: "#FFB3BA"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "24E8930C-8A59-48B2-8818-A2FD18D49E74")!,
+                    index: 1,
+                    name: "A",
+                    colorHex: "#FFDFBA"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "A46E9E6C-A920-43B3-B0F2-34675C65775A")!,
+                    index: 2,
+                    name: "B",
+                    colorHex: "#FFFFBA"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "633E0E25-DA02-436E-8B19-6254053F5E47")!,
+                    index: 3,
+                    name: "C",
+                    colorHex: "#BAFFC9"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "899731EF-9F1F-4C89-99C0-1B9F9F80F28E")!,
+                    index: 4,
+                    name: "D",
+                    colorHex: "#BAE1FF"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "4EEFC128-8CEA-4934-A6C2-4E14A83C669A")!,
+                    index: 5,
+                    name: "F",
+                    colorHex: "#E2E2E2"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "62F07389-A08B-4C1C-8BB4-80C0D6498C44")!,
+                    index: 6,
+                    name: "Unranked",
+                    colorHex: "#CCCCCC",
+                    isUnranked: true
+                )
+            ]
+        ),
+        TierThemeEntity(
+            themeID: UUID(uuidString: "25D36C02-2640-4D1B-89EB-8182A81756E9")!,
+            slug: "monochrome",
+            displayName: "Monochrome",
+            shortDescription: "Grayscale spectrum",
+            tiers: [
+                TierColorEntity(
+                    tierID: UUID(uuidString: "5F7B0C10-80C9-4F2E-940C-7A7A1A92C92F")!,
+                    index: 0,
+                    name: "S",
+                    colorHex: "#000000"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "FD3B399E-17B8-40EC-9E11-89ED59973587")!,
+                    index: 1,
+                    name: "A",
+                    colorHex: "#4C4C4C"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "D89E15E4-3E59-4DF1-8159-7B3A2FCC20F6")!,
+                    index: 2,
+                    name: "B",
+                    colorHex: "#7F7F7F"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "85F6A27E-4D26-4ABE-BE5D-3CD8A987C72F")!,
+                    index: 3,
+                    name: "C",
+                    colorHex: "#B3B3B3"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "C1C24FC9-8885-4F83-9A7F-3A53A1C8EE9D")!,
+                    index: 4,
+                    name: "D",
+                    colorHex: "#CCCCCC"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "0B4D23E4-F1B8-4453-A42A-CED3071E7B93")!,
+                    index: 5,
+                    name: "F",
+                    colorHex: "#FFFFFF"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "19F1E2AC-46A7-432C-A140-FA1AB05A1624")!,
+                    index: 6,
+                    name: "Unranked",
+                    colorHex: "#808080",
+                    isUnranked: true
+                )
+            ]
+        ),
+        TierThemeEntity(
+            themeID: UUID(uuidString: "6A3D2B92-AC90-4764-8F07-BF78D78F27FB")!,
+            slug: "rainbow",
+            displayName: "Rainbow",
+            shortDescription: "Full color spectrum",
+            tiers: [
+                TierColorEntity(
+                    tierID: UUID(uuidString: "523974D5-B7A0-43B7-A69D-6F92FE453A45")!,
+                    index: 0,
+                    name: "S",
+                    colorHex: "#FF0000"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "7E20A8D1-40C4-4A07-8F04-9FBA7F5A120B")!,
+                    index: 1,
+                    name: "A",
+                    colorHex: "#FF8000"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "3F1F0D76-F380-4C0A-8ED4-700D02CFE2C2")!,
+                    index: 2,
+                    name: "B",
+                    colorHex: "#FFFF00"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "93DEE536-9538-4F74-9177-58E09F89CF3F")!,
+                    index: 3,
+                    name: "C",
+                    colorHex: "#00FF00"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "A0A212DA-C58E-4559-85A7-031E13C69C01")!,
+                    index: 4,
+                    name: "D",
+                    colorHex: "#0000FF"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "54C5069F-FF92-4B6E-8CFA-621D3C0D21EB")!,
+                    index: 5,
+                    name: "F",
+                    colorHex: "#8B00FF"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "7525DFB5-7A5F-4F8A-82E4-E4B849E9AA03")!,
+                    index: 6,
+                    name: "Unranked",
+                    colorHex: "#808080",
+                    isUnranked: true
+                )
+            ]
+        ),
+        TierThemeEntity(
+            themeID: UUID(uuidString: "AA363109-ED06-4D37-8BE3-7A53704A81C6")!,
+            slug: "darkNeon",
+            displayName: "Dark Neon",
+            shortDescription: "Vibrant neon on dark",
+            tiers: [
+                TierColorEntity(
+                    tierID: UUID(uuidString: "8A4F9787-FE6A-4C08-A4ED-B0FF61728B8C")!,
+                    index: 0,
+                    name: "S",
+                    colorHex: "#FF2A6D"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "D705CEB9-7C02-4580-A69B-9294DE06C180")!,
+                    index: 1,
+                    name: "A",
+                    colorHex: "#FF7A00"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "80C3AAF4-124C-4C15-8C71-0851FF849990")!,
+                    index: 2,
+                    name: "B",
+                    colorHex: "#FFD300"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "CBB58FC2-C88E-4F93-A02D-A87601B68071")!,
+                    index: 3,
+                    name: "C",
+                    colorHex: "#39FF14"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "10755696-D01E-48B6-B4EC-7EEFF0E5AA3E")!,
+                    index: 4,
+                    name: "D",
+                    colorHex: "#00E5FF"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "6A8DE85D-68C7-4747-9DBD-108E6236FA59")!,
+                    index: 5,
+                    name: "F",
+                    colorHex: "#7C00FF"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "E58E5B1E-080F-4A4E-9E3E-3AA047B12B21")!,
+                    index: 6,
+                    name: "Unranked",
+                    colorHex: "#374151",
+                    isUnranked: true
+                )
+            ]
+        ),
+        TierThemeEntity(
+            themeID: UUID(uuidString: "21ABDA2A-B7BB-4C92-9C7D-B81987EEB828")!,
+            slug: "nord",
+            displayName: "Nord",
+            shortDescription: "Scandinavian palette",
+            tiers: [
+                TierColorEntity(
+                    tierID: UUID(uuidString: "53CFFF04-3C75-42F4-A736-6096255D08D1")!,
+                    index: 0,
+                    name: "S",
+                    colorHex: "#BF616A"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "8F49591A-84BD-4680-9AC0-47789FFC1A0D")!,
+                    index: 1,
+                    name: "A",
+                    colorHex: "#D08770"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "B31E2BD4-31FA-4D35-AF77-1972AFE6E6F2")!,
+                    index: 2,
+                    name: "B",
+                    colorHex: "#EBCB8B"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "523F67B3-1F0B-4B70-A578-FA2DB13A9A6F")!,
+                    index: 3,
+                    name: "C",
+                    colorHex: "#A3BE8C"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "6E7C6C31-04B6-4546-B58A-5C9D33EAAF5F")!,
+                    index: 4,
+                    name: "D",
+                    colorHex: "#88C0D0"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "8F5ED11B-048D-462E-A960-4CB14559C5F6")!,
+                    index: 5,
+                    name: "F",
+                    colorHex: "#5E81AC"
+                ),
+                TierColorEntity(
+                    tierID: UUID(uuidString: "6D487EDB-8AF0-4168-9461-CC3E7C79C43E")!,
+                    index: 6,
+                    name: "Unranked",
+                    colorHex: "#4C566A",
+                    isUnranked: true
+                )
+            ]
+        )
+    ]
+}

--- a/Tiercade/State/AppState+Theme.swift
+++ b/Tiercade/State/AppState+Theme.swift
@@ -7,6 +7,7 @@ extension AppState {
     /// Applies the selected theme to all tiers
     func applyTheme(_ theme: TierTheme) {
         selectedTheme = theme
+        selectedThemeID = theme.id
         applyCurrentTheme()
         try? save()
         showSuccessToast("Theme '\(theme.displayName)' applied")
@@ -14,9 +15,10 @@ extension AppState {
 
     /// Applies the currently selected theme to all tier colors
     func applyCurrentTheme() {
-        for tierId in tierOrder + ["unranked"] {
-            tierColors[tierId] = selectedTheme.color(for: tierId)
+        for (index, tierId) in tierOrder.enumerated() {
+            tierColors[tierId] = selectedTheme.colorHex(forRank: tierId, fallbackIndex: index)
         }
+        tierColors["unranked"] = selectedTheme.unrankedColorHex
         hasUnsavedChanges = true
     }
 

--- a/Tiercade/Views/Components/BuildInfoView.swift
+++ b/Tiercade/Views/Components/BuildInfoView.swift
@@ -10,7 +10,7 @@ struct BuildInfoView: View {
         return ""
         #endif
     }
-    
+
     private var formattedBuildTime: String {
         #if DEBUG
         let now = Date()
@@ -21,7 +21,7 @@ struct BuildInfoView: View {
         return ""
         #endif
     }
-    
+
     var body: some View {
         #if DEBUG
         Text("Build: \(formattedBuildTime)")

--- a/Tiercade/Views/Main/MainAppView.swift
+++ b/Tiercade/Views/Main/MainAppView.swift
@@ -13,54 +13,83 @@ struct MainAppView: View {
     @Environment(AppState.self) private var app: AppState
     #if os(tvOS)
     @Environment(\.scenePhase) private var scenePhase
-    @Environment(\.resetFocus) private var resetFocus
-    @Namespace private var focusNamespace
-    @FocusState private var focusedRegion: FocusRegion?
     @FocusState private var detailFocus: DetailFocus?
-    @State private var didBootstrapFocus = false
-    @State private var lastBaseRegion: FocusRegion = .grid
     enum DetailFocus: Hashable { case close }
     #endif
 
     var body: some View {
-        let detailPresented = app.detailItem != nil
-        let headToHeadPresented = app.h2hActive
-        let quickRankPresented = app.quickRankTarget != nil
-        let tierListBrowserPresented = app.showingTierListBrowser
-        let themePickerPresented = app.showThemePicker
+    let detailPresented = app.detailItem != nil
+    let headToHeadPresented = app.h2hActive
+    // Use the requested overlay visibility (showThemePicker) rather than the
+    // overlay's internal active flag. The active flag is set in the overlay's
+    // onAppear, which can introduce a race where the toolbar remains
+    // interactive briefly and focus can escape. Use showThemePicker so hit
+    // testing is blocked immediately when the overlay is requested.
+    let themePickerPresented = app.showThemePicker
+    #if os(tvOS)
+    let modalBlockingFocus = headToHeadPresented || detailPresented || themePickerPresented
+    #else
+    let modalBlockingFocus = detailPresented || headToHeadPresented || themePickerPresented
+    #endif
+
+        return Group {
+            #if os(macOS) || targetEnvironment(macCatalyst)
+            NavigationSplitView {
+                SidebarView(tierOrder: app.tierOrder)
+                    .environment(app)
+            } content: {
+                TierGridView(tierOrder: app.tierOrder)
+                    .environment(app)
+            } detail: {
+                EmptyView()
+            }
+            .toolbar { ToolbarView(app: app) }
+            #else
+            // For iOS/tvOS show content full-bleed and inject bars via safe area insets
+            ZStack {
+                TierGridView(tierOrder: app.tierOrder)
+                    .environment(app)
+                    // Add content padding to avoid overlay bars overlap
+                    .padding(.top, TVMetrics.contentTopInset)
+                    .padding(.bottom, TVMetrics.contentBottomInset)
+                    .allowsHitTesting(!modalBlockingFocus)
+                // Note: Don't use .disabled() as it removes elements from accessibility tree
+                // Only block hit testing when modals are active
+            }
+            #if os(tvOS)
+            // Top toolbar (overlay so it doesn't reduce content area)
+            .overlay(alignment: .top) {
+                TVToolbarView(app: app)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .frame(height: TVMetrics.topBarHeight)
+                    .background(.thinMaterial)
+                    .overlay(Divider().opacity(0.15), alignment: .bottom)
+                    .allowsHitTesting(!modalBlockingFocus)
+                    .accessibilityElement(children: .contain)
+                // Note: Don't use .disabled() as it removes elements from accessibility tree
+                // Only block hit testing when modals are active
+            }
+            // Bottom action bar (safe area inset to avoid covering focused rows)
+            .overlay(alignment: .bottom) {
+                TVActionBar(app: app)
+                    .allowsHitTesting(!modalBlockingFocus)
+                    .accessibilityElement(children: .contain)
+                // Note: Don't use .disabled() as it removes elements from accessibility tree
+                // Only block hit testing when modals are active
+            }
+            #else
+            // ToolbarView is ToolbarContent (not a View) on some platforms; avoid embedding it directly on tvOS
+            .overlay(alignment: .top) {
+            HStack { Text("") }
+            .environment(app)
+            }
+            #endif
+            #endif
+        }
         #if os(tvOS)
-    _ = app.quickMoveTarget != nil
-    _ = app.itemMenuTarget != nil
-    _ = app.showAnalyticsSidebar
-        let overlayRegion = determineOverlayRegion()
-        let modalBlockingFocus = overlayRegion != nil
-        #else
-        let baseModal = detailPresented || headToHeadPresented || themePickerPresented
-        let modalBlockingFocus = baseModal || quickRankPresented || tierListBrowserPresented
-        #endif
-        return platformContent(overlayBlockingFocus: modalBlockingFocus)
-        #if os(tvOS)
-        .focusScope(focusNamespace)
-        .task {
-            FocusUtils.seedFocus()
-            bootstrapInitialFocus(for: overlayRegion)
-        }
-        .onAppear {
-            alignFocus(to: overlayRegion)
-        }
-        .onChange(of: overlayRegion) { _, newValue in
-            alignFocus(to: newValue)
-        }
+        .task { FocusUtils.seedFocus() }
         .onChange(of: scenePhase) { _, newPhase in
-            if newPhase == .active {
-                FocusUtils.seedFocus()
-                alignFocus(to: overlayRegion)
-            }
-        }
-        .onChange(of: focusedRegion) { _, newValue in
-            if let region = newValue, !region.isOverlay {
-                lastBaseRegion = region
-            }
+            if newPhase == .active { FocusUtils.seedFocus() }
         }
         .onExitCommand {
             if app.showingTierListBrowser {
@@ -89,31 +118,19 @@ struct MainAppView: View {
 
                 // Quick Rank overlay
                 QuickRankOverlay(app: app)
-                    #if os(tvOS)
-                    .focused($focusedRegion, equals: .quickRank)
-                    .prefersDefaultFocus(in: focusNamespace)
-                    #endif
                     .zIndex(40)
 
                 #if os(tvOS)
                 // Quick Move overlay for tvOS Play/Pause accelerator
                 QuickMoveOverlay(app: app)
-                    .focused($focusedRegion, equals: .quickMove)
-                    .prefersDefaultFocus(in: focusNamespace)
                     .zIndex(45)
                 // Item Menu overlay (primary action)
                 ItemMenuOverlay(app: app)
-                    .focused($focusedRegion, equals: .itemMenu)
-                    .prefersDefaultFocus(in: focusNamespace)
                     .zIndex(46)
                 #endif
 
                 // Head-to-Head overlay
                 HeadToHeadOverlay(app: app)
-                    #if os(tvOS)
-                    .focused($focusedRegion, equals: .headToHead)
-                    .prefersDefaultFocus(in: focusNamespace)
-                    #endif
                     .zIndex(40)
 
                 #if os(tvOS)
@@ -124,18 +141,12 @@ struct MainAppView: View {
                             .frame(maxHeight: .infinity)
                     }
                     .allowsHitTesting(true)
-                    .focused($focusedRegion, equals: .analytics)
-                    .prefersDefaultFocus(in: focusNamespace)
                     .zIndex(52)
                 }
                 #endif
 
                 if app.showingTierListBrowser {
                     TierListBrowserScene(app: app)
-                        #if os(tvOS)
-                        .focused($focusedRegion, equals: .tierBrowser)
-                        .prefersDefaultFocus(in: focusNamespace)
-                        #endif
                         .transition(.opacity)
                         .zIndex(53)
                 }
@@ -149,18 +160,10 @@ struct MainAppView: View {
                     // XCTest sees elements, causing flaky existence checks.
                     if ProcessInfo.processInfo.arguments.contains("-uiTest") {
                         ThemePickerOverlay(appState: app)
-                            #if os(tvOS)
-                            .focused($focusedRegion, equals: .themePicker)
-                            .prefersDefaultFocus(in: focusNamespace)
-                            #endif
                             .zIndex(54)
                     } else {
                         ThemePickerOverlay(appState: app)
                             .transition(.opacity.combined(with: .scale(scale: 0.9)))
-                            #if os(tvOS)
-                            .focused($focusedRegion, equals: .themePicker)
-                            .prefersDefaultFocus(in: focusNamespace)
-                            #endif
                             .zIndex(54)
                     }
                 }
@@ -174,21 +177,6 @@ struct MainAppView: View {
                     }
                     .zIndex(60)
                 }
-
-                // Build timestamp (DEBUG only, bottom-right corner)
-                #if DEBUG
-                VStack {
-                    Spacer()
-                    HStack {
-                        Spacer()
-                        BuildInfoView()
-                            .padding(.trailing, 16)
-                            .padding(.bottom, 16)
-                    }
-                }
-                .zIndex(61)
-                .allowsHitTesting(false)
-                #endif
 
                 // Bottom action bar is inset on tvOS via safeAreaInset above; no overlay here
 
@@ -204,8 +192,6 @@ struct MainAppView: View {
                     .defaultFocus($detailFocus, .close)
                     .onAppear { detailFocus = .close }
                     .onDisappear { detailFocus = nil }
-                    .focused($focusedRegion, equals: .detail)
-                    .prefersDefaultFocus(in: focusNamespace)
                     .transition(
                         .move(edge: .trailing)
                             .combined(with: .opacity)
@@ -268,104 +254,6 @@ struct MainAppView: View {
     }
 }
 
-private extension MainAppView {
-    @ViewBuilder
-    func platformContent(overlayBlockingFocus: Bool) -> some View {
-        #if os(macOS) || targetEnvironment(macCatalyst)
-        NavigationSplitView {
-            SidebarView(tierOrder: app.tierOrder)
-                .environment(app)
-        } content: {
-            TierGridView(tierOrder: app.tierOrder)
-                .environment(app)
-        } detail: {
-            EmptyView()
-        }
-        .toolbar { ToolbarView(app: app) }
-        #else
-        // For iOS/tvOS show content full-bleed and inject bars via safe area insets
-        ZStack {
-            TierGridView(tierOrder: app.tierOrder)
-                .environment(app)
-                // Add content padding to avoid overlay bars overlap
-                .padding(.top, TVMetrics.contentTopInset)
-                .padding(.bottom, TVMetrics.contentBottomInset)
-                .disabled(overlayBlockingFocus)
-            #if os(tvOS)
-                .focusSection()
-                .focused($focusedRegion, equals: .grid)
-                .prefersDefaultFocus(in: focusNamespace)
-            #endif
-        }
-        #if os(tvOS)
-        // Top toolbar (overlay so it doesn't reduce content area)
-        .overlay(alignment: .top) {
-            TVToolbarView(app: app)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .frame(height: TVMetrics.topBarHeight)
-                .background(.thinMaterial)
-                .overlay(Divider().opacity(0.15), alignment: .bottom)
-                .focused($focusedRegion, equals: .toolbar)
-                .prefersDefaultFocus(in: focusNamespace)
-                .disabled(overlayBlockingFocus)
-                .accessibilityElement(children: AccessibilityChildBehavior.contain)
-        }
-        // Bottom action bar (safe area inset to avoid covering focused rows)
-        .overlay(alignment: .bottom) {
-            TVActionBar(app: app)
-                .focused($focusedRegion, equals: .actionBar)
-                .prefersDefaultFocus(in: focusNamespace)
-                .disabled(overlayBlockingFocus)
-                .accessibilityElement(children: AccessibilityChildBehavior.contain)
-        }
-        #else
-        // ToolbarView is ToolbarContent (not a View) on some platforms; avoid embedding it directly on tvOS
-        .overlay(alignment: .top) {
-            HStack { Text("") }
-                .environment(app)
-        }
-        #endif
-        #endif
-    }
-
-    #if os(tvOS)
-    private func determineOverlayRegion() -> FocusRegion? {
-        let candidates: [FocusRegion?] = [
-            app.h2hActive ? .headToHead : nil,
-            app.detailItem != nil ? .detail : nil,
-            app.showThemePicker ? .themePicker : nil,
-            app.showingTierListBrowser ? .tierBrowser : nil,
-            app.itemMenuTarget != nil ? .itemMenu : nil,
-            app.quickMoveTarget != nil ? .quickMove : nil,
-            app.quickRankTarget != nil ? .quickRank : nil,
-            app.showAnalyticsSidebar ? .analytics : nil
-        ]
-        return candidates.compactMap { $0 }.first
-    }
-
-    @MainActor
-    private func alignFocus(to overlay: FocusRegion?) {
-        let target: FocusRegion = {
-            if let overlay {
-                return overlay
-            }
-            return lastBaseRegion
-        }()
-        if focusedRegion != target {
-            focusedRegion = target
-        }
-        resetFocus(in: focusNamespace)
-    }
-
-    @MainActor
-    private func bootstrapInitialFocus(for overlay: FocusRegion?) {
-        guard !didBootstrapFocus else { return }
-        didBootstrapFocus = true
-        alignFocus(to: overlay)
-    }
-    #endif
-}
-
 // Small preview
 #Preview("Main") { MainAppView() }
 
@@ -388,7 +276,7 @@ struct TVToolbarView: View {
     @FocusState private var focusedControl: Control?
 
     private enum Control: Hashable {
-        case undo, redo, library, randomize, reset, tierMenu, h2h, analytics, theme
+        case undo, redo, randomize, reset, library, h2h, analytics, theme
     }
 
     var body: some View {
@@ -436,21 +324,6 @@ struct TVToolbarView: View {
             .accessibilityLabel("Redo")
             .focusTooltip("Redo")
 
-            Divider()
-
-            Button(action: { app.presentTierListBrowser() }, label: {
-                Image(systemName: "square.grid.2x2")
-                    .font(.system(size: Metrics.toolbarIconSize))
-                    .frame(width: Metrics.toolbarButtonSize, height: Metrics.toolbarButtonSize)
-            })
-            .buttonStyle(.tvRemote(.primary))
-            .focused($focusedControl, equals: .library)
-            .accessibilityIdentifier("Toolbar_BundledLibrary")
-            .accessibilityLabel("Bundled Tier Lists")
-            .accessibilityHint("Browse built-in tier lists to start ranking")
-            .focusTooltip("Tier Library")
-            .disabled(app.showingTierListBrowser)
-
             Button(action: { app.randomize() }, label: {
                 Image(systemName: "shuffle")
                     .font(.system(size: Metrics.toolbarIconSize))
@@ -475,12 +348,19 @@ struct TVToolbarView: View {
             .accessibilityLabel("Reset")
             .focusTooltip("Reset")
 
-            TierListQuickMenu(app: app)
-                .focused($focusedControl, equals: .tierMenu)
-                .focusTooltip("Choose tier list")
-                .padding(.leading, 12)
+            Divider()
+                .frame(height: 28)
 
-            Spacer(minLength: 0)
+            Spacer(minLength: 28)
+
+            TierListQuickMenu(app: app)
+                .focused($focusedControl, equals: .library)
+                .focusTooltip("Tier Library")
+
+            Spacer(minLength: 28)
+
+            Divider()
+                .frame(height: 28)
 
             Button(action: { app.startH2H() }, label: {
                 Image(systemName: "person.line.dotted.person.fill")

--- a/Tiercade/Views/Toolbar/TVActionBar.swift
+++ b/Tiercade/Views/Toolbar/TVActionBar.swift
@@ -13,25 +13,68 @@ struct TVActionBar: View {
 
             HStack(spacing: 20) {
                 Button {
-                    app.isMultiSelect.toggle()
-                    if !app.isMultiSelect { app.clearSelection() }
+                    withAnimation(.snappy(duration: 0.18, extraBounce: 0.04)) {
+                        app.isMultiSelect.toggle()
+                        if !app.isMultiSelect { app.clearSelection() }
+                    }
                 } label: {
-                    HStack(spacing: 12) {
-                        Text("Multi-Select")
+                    HStack(spacing: 16) {
+                        Image(systemName: app.isMultiSelect ? "checkmark.circle.fill" : "circle")
+                            .font(.title2.weight(.semibold))
+                            .foregroundStyle(app.isMultiSelect ? Palette.brand : Palette.textDim)
+
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Multi-Select")
+                                .font(.title3.weight(.semibold))
+                                .foregroundStyle(.primary)
+
+                            Text("Enabled")
+                                .font(.footnote.weight(.semibold))
+                                .foregroundStyle(Palette.brand)
+                                .opacity(app.isMultiSelect ? 1 : 0)
+                                .accessibilityHidden(!app.isMultiSelect)
+                        }
+
+                        Spacer()
+
                         if app.isMultiSelect {
                             Capsule()
-                                .fill(Color.white.opacity(0.2))
-                                .frame(width: 2, height: 24)
-                            Text("\(app.selection.count)")
-                                .font(.callout.weight(.semibold))
-                                .transition(.scale.combined(with: .opacity))
+                                .fill(Palette.brand.opacity(0.28))
+                                .overlay(
+                                    HStack(spacing: 8) {
+                                        Image(systemName: "square.stack.3d.up.fill")
+                                            .font(.callout.weight(.semibold))
+                                        Text("Active · \(app.selection.count)")
+                                            .font(.callout.weight(.semibold))
+                                    }
+                                        .foregroundStyle(Color.white)
+                                        .padding(.horizontal, 14)
+                                        .padding(.vertical, 6)
+                                )
                                 .accessibilityIdentifier("ActionBar_SelectionCount")
+                                .transition(.move(edge: .trailing).combined(with: .opacity))
                         }
                     }
+                    .padding(.horizontal, 22)
+                    .padding(.vertical, 14)
                     .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(multiSelectBackground)
+                    .clipShape(RoundedRectangle(cornerRadius: 28, style: .continuous))
+                    .contentShape(RoundedRectangle(cornerRadius: 28, style: .continuous))
                 }
                 .buttonStyle(.tvRemote(.secondary))
+                .animation(.easeOut(duration: 0.18), value: app.isMultiSelect)
                 .accessibilityIdentifier("ActionBar_MultiSelect")
+                .accessibilityValue(
+                    app.isMultiSelect
+                        ? "Multi-select on with \(app.selection.count) selected"
+                        : "Multi-select off"
+                )
+                .accessibilityHint(
+                    app.isMultiSelect
+                        ? "Press to exit multi-select"
+                        : "Press to enable multi-select"
+                )
 
                 Divider().frame(height: 28)
 
@@ -64,6 +107,18 @@ struct TVActionBar: View {
         // For UI testing, we need elements to be accessible even when not focused
         // NOTE: Don't set accessibilityIdentifier on the container - it overrides children!
         .accessibilityElement(children: .contain)
+    }
+
+    private var multiSelectBackground: some View {
+        RoundedRectangle(cornerRadius: 28, style: .continuous)
+            .fill(app.isMultiSelect ? Palette.brand.opacity(0.22) : Color.white.opacity(0.04))
+            .overlay(
+                RoundedRectangle(cornerRadius: 28, style: .continuous)
+                    .stroke(
+                        app.isMultiSelect ? Palette.brand : Color.white.opacity(0.12),
+                        lineWidth: app.isMultiSelect ? 2 : 1
+                    )
+            )
     }
 }
 #endif

--- a/Tiercade/Views/Toolbar/TierListQuickMenu.swift
+++ b/Tiercade/Views/Toolbar/TierListQuickMenu.swift
@@ -49,6 +49,45 @@ struct TierListQuickMenu: View {
     }
 
     private var menuLabel: some View {
+        #if os(tvOS)
+        VStack(spacing: 10) {
+            Text("Tier Library")
+                .font(TypeScale.body)
+                .fontWeight(.semibold)
+                .foregroundStyle(Palette.textDim)
+
+            HStack(spacing: 14) {
+                Image(systemName: "square.grid.2x2")
+                    .font(.system(size: 38, weight: .semibold))
+
+                Text(app.activeTierDisplayName)
+                    .font(TypeScale.h3)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
+                    .accessibilityIdentifier("Toolbar_TierListMenu_Title")
+            }
+            .foregroundStyle(Palette.text)
+
+            Text("Browse bundled & saved lists")
+                .font(TypeScale.label)
+                .fontWeight(.semibold)
+                .foregroundStyle(Palette.textDim)
+                .opacity(0.9)
+        }
+        .multilineTextAlignment(.center)
+        .padding(.horizontal, 44)
+        .padding(.vertical, 22)
+        .frame(minWidth: 420)
+        .background(
+            RoundedRectangle(cornerRadius: 36, style: .continuous)
+                .fill(Color.white.opacity(0.16))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 36, style: .continuous)
+                        .stroke(Color.white.opacity(0.28), lineWidth: 1.2)
+                )
+        )
+        .contentShape(RoundedRectangle(cornerRadius: 36, style: .continuous))
+        #else
         HStack(spacing: 12) {
             Image(systemName: "list.bullet.rectangle")
                 .font(.system(size: 22, weight: .semibold))
@@ -75,6 +114,7 @@ struct TierListQuickMenu: View {
                     )
                 )
         )
+        #endif
     }
 
     private func quickPickButton(for handle: TierListHandle) -> some View {

--- a/TiercadeUITests/tvOS/tvOSThemePickerOverlayFocusTests.swift
+++ b/TiercadeUITests/tvOS/tvOSThemePickerOverlayFocusTests.swift
@@ -1,7 +1,6 @@
 #if os(tvOS)
 import XCTest
 
-
 class ThemePickerOverlayFocusTests: XCTestCase {
     override func setUp() {
         super.setUp()


### PR DESCRIPTION
## Summary
- migrate Tier theme handling to SwiftData catalog with deterministic seeds
- persist selected theme using UUIDs and add reseed safety for bundled placeholders
- refresh tvOS toolbar, quick menu, and action bar polish with updated focus/accessibility

## Testing
- xcodebuild -project Tiercade.xcodeproj -scheme Tiercade -destination 'platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=latest' -configuration Debug build
- xcrun simctl install "Apple TV 4K (3rd generation)" Tiercade.app