### PR TITLE
feat(tvOS): polish overlay UX and tier management

### DIFF
--- a/Tiercade/State/AppState+Selection.swift
+++ b/Tiercade/State/AppState+Selection.swift
@@ -29,8 +29,9 @@ extension AppState {
 
     func move(_ id: String, to tier: String) {
         if lockedTiers.contains(tier) {
-            showErrorToast("Tier Locked", message: "Cannot move into \(tier)")
-            announce("Tier \(tier) is locked. Move canceled.")
+            let displayTier = displayLabel(for: tier)
+            showErrorToast("Tier Locked", message: "Cannot move into \(displayTier)")
+            announce("Tier \(displayTier) is locked. Move canceled.")
             return
         }
         let next = TierLogic.moveItem(tiers, itemId: id, targetTierName: tier)
@@ -38,12 +39,13 @@ extension AppState {
         tiers = next
         history = HistoryLogic.saveSnapshot(history, snapshot: tiers)
         markAsChanged()
+        let displayTier = displayLabel(for: tier)
         if let name = tiers[tier]?.first(where: { $0.id == id })?.name {
-            showInfoToast("Moved", message: "Moved ‘\(name)’ to \(tier)")
-            announce("Moved ‘\(name)’ to \(tier) tier")
+            showInfoToast("Moved", message: "Moved '\(name)' to \(displayTier)")
+            announce("Moved '\(name)' to \(displayTier) tier")
         } else {
-            showInfoToast("Moved", message: "Moved to \(tier)")
-            announce("Moved to \(tier) tier")
+            showInfoToast("Moved", message: "Moved to \(displayTier)")
+            announce("Moved to \(displayTier) tier")
         }
         let counts = tierOrder
             .map { "\($0):\(tiers[$0]?.count ?? 0)" }
@@ -53,9 +55,10 @@ extension AppState {
 
     func batchMove(_ ids: [String], to tier: String) {
         guard !ids.isEmpty else { return }
+        let displayTier = displayLabel(for: tier)
         guard !lockedTiers.contains(tier) else {
-            showErrorToast("Tier Locked", message: "Cannot move into \(tier)")
-            announce("Tier \(tier) is locked. Move canceled.")
+            showErrorToast("Tier Locked", message: "Cannot move into \(displayTier)")
+            announce("Tier \(displayTier) is locked. Move canceled.")
             return
         }
         var next = tiers
@@ -67,9 +70,9 @@ extension AppState {
         history = HistoryLogic.saveSnapshot(history, snapshot: tiers)
         markAsChanged()
         clearSelection()
-        showSuccessToast("Moved Items", message: "Moved \(ids.count) item(s) to \(tier)")
+        showSuccessToast("Moved Items", message: "Moved \(ids.count) item(s) to \(displayTier)")
         let count = ids.count
-        let announcement = "Moved \(count) item\(count == 1 ? "" : "s") to \(tier) tier"
+        let announcement = "Moved \(count) item\(count == 1 ? "" : "s") to \(displayTier) tier"
         announce(announcement)
     }
 
@@ -92,9 +95,10 @@ extension AppState {
         tiers = next
         history = HistoryLogic.saveSnapshot(history, snapshot: tiers)
         markAsChanged()
-        let toastMessage = "Moved all items from \(tier) tier to unranked"
+        let displayTier = displayLabel(for: tier)
+        let toastMessage = "Moved all items from \(displayTier) tier to Unranked"
         showInfoToast("Tier Cleared", message: toastMessage)
-        let announcement = "Cleared \(tier) tier. Moved \(moving.count) item\(moving.count == 1 ? "" : "s") to unranked"
+        let announcement = "Cleared \(displayTier) tier. Moved \(moving.count) item\(moving.count == 1 ? "" : "s") to Unranked"
         announce(announcement)
     }
 

--- a/Tiercade/Views/Main/MainAppView.swift
+++ b/Tiercade/Views/Main/MainAppView.swift
@@ -22,10 +22,12 @@ struct MainAppView: View {
     let detailPresented = app.detailItem != nil
     let headToHeadPresented = app.h2hActive
     let themeCreatorPresented = app.showThemeCreator
+    let itemMenuPresented = app.itemMenuTarget != nil
+    let quickMovePresented = app.quickMoveTarget != nil
     // Note: ThemePicker, TierListBrowser, and Analytics now use .fullScreenCover()
     // which provides automatic focus containment via separate presentation context
     #if os(tvOS)
-    let modalBlockingFocus = headToHeadPresented || detailPresented || themeCreatorPresented
+    let modalBlockingFocus = headToHeadPresented || detailPresented || themeCreatorPresented || itemMenuPresented || quickMovePresented
     #else
     let modalBlockingFocus = detailPresented || headToHeadPresented || themeCreatorPresented
     #endif
@@ -90,7 +92,11 @@ struct MainAppView: View {
             if newPhase == .active { FocusUtils.seedFocus() }
         }
         .onExitCommand {
-            if app.showThemeCreator {
+            if app.itemMenuTarget != nil {
+                app.dismissItemMenu()
+            } else if app.quickMoveTarget != nil {
+                app.cancelQuickMove()
+            } else if app.showThemeCreator {
                 app.cancelThemeCreation(returnToThemePicker: false)
             } else if app.showingTierListBrowser {
                 app.dismissTierListBrowser()

--- a/Tiercade/Views/Overlays/QuickMoveOverlay.swift
+++ b/Tiercade/Views/Overlays/QuickMoveOverlay.swift
@@ -7,14 +7,17 @@ struct QuickMoveOverlay: View {
 
     @FocusState private var focused: FocusField?
 
-    private enum FocusField: Hashable { case s, a, b, c, u, more, cancel }
+    private enum FocusField: Hashable { case s, a, b, c, u, more, cancel, backgroundTrap }
 
     var body: some View {
         if let item = app.quickMoveTarget {
             ZStack {
+                // Focus-trapping background: Focusable to catch stray focus and redirect back
                 Color.black.opacity(0.65)
                     .ignoresSafeArea()
                     .onTapGesture { app.cancelQuickMove() }
+                    .focusable()
+                    .focused($focused, equals: .backgroundTrap)
                     .accessibilityHidden(true)
 
                 VStack(spacing: 16) {


### PR DESCRIPTION
## Summary
- Improve overlay focus containment with focus-trapping backgrounds
- Enhance ItemMenuOverlay to show current tier with checkmark indicator
- Normalize tier name handling (especially "Unranked" variants)
- Improve randomize distribution logic (excludes unranked, guarantees coverage)
- Use display labels consistently across all user-facing messages

## Test plan
- [x] ItemMenuOverlay shows checkmark on current tier and disables button
- [x] Menu button dismisses ItemMenu and QuickMove overlays
- [x] Focus cannot escape overlay boundaries
- [x] Randomize distributes items only to ranked tiers
- [x] All toasts/announcements use proper tier display labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)